### PR TITLE
[app] Init dashboard route

### DIFF
--- a/diagnostics-app/src/app/app-routing.module.ts
+++ b/diagnostics-app/src/app/app-routing.module.ts
@@ -4,16 +4,20 @@
 
 /**
  * @fileoverview Defines routes for app.module
- * Imported by app.module.ts 
+ * Imported by app.module.ts
  */
 
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { DashboardComponent } from './dashboard/dashboard/dashboard.component';
 
-const routes: Routes = [];
+const routes: Routes = [
+  { path: '', redirectTo: '/dashboard', pathMatch: 'full' },
+  { path: 'dashboard', component: DashboardComponent },
+];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],
-  exports: [RouterModule]
+  exports: [RouterModule],
 })
-export class AppRoutingModule { }
+export class AppRoutingModule {}

--- a/diagnostics-app/src/app/app.component.it.spec.ts
+++ b/diagnostics-app/src/app/app.component.it.spec.ts
@@ -10,10 +10,9 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { AppComponent } from './app.component';
 import { Theme } from './core/enums/global.enums';
 import { ThemeService } from './core/services/theme.service';
-
-import { AppComponent } from './app.component';
 
 describe('integration: component: app', () => {
   let fixture: ComponentFixture<AppComponent>;

--- a/diagnostics-app/src/app/app.module.ts
+++ b/diagnostics-app/src/app/app.module.ts
@@ -16,13 +16,13 @@ import { environment } from '../environments/environment';
 import { AppRoutingModule } from './app-routing.module';
 import { CoreModule } from './core/core.module';
 import { SharedModule } from './shared/shared.module';
-import { LayoutModule } from '@angular/cdk/layout';
+import { DashboardModule } from './dashboard/dashboard.module';
 
 import { AppComponent } from './app.component';
-import { HeaderComponent } from './layout/header/header.component';
 import { ContentLayoutComponent } from './layout/content-layout/content-layout.component';
-import { SideNavComponent } from './layout/side-nav/side-nav.component';
+import { HeaderComponent } from './layout/header/header.component';
 import { SideNavItemComponent } from './layout/side-nav/side-nav-item/side-nav-item.component';
+import { SideNavComponent } from './layout/side-nav/side-nav.component';
 
 @NgModule({
   declarations: [
@@ -43,7 +43,7 @@ import { SideNavItemComponent } from './layout/side-nav/side-nav-item/side-nav-i
     }),
     CoreModule,
     SharedModule,
-    LayoutModule,
+    DashboardModule,
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/diagnostics-app/src/app/core/services/theme.service.unit.spec.ts
+++ b/diagnostics-app/src/app/core/services/theme.service.unit.spec.ts
@@ -7,8 +7,8 @@
  */
 
 import { TestBed } from '@angular/core/testing';
-import { Theme } from '../enums/global.enums';
 
+import { Theme } from '../enums/global.enums';
 import { ThemeService } from './theme.service';
 
 describe('unit: service: theme', () => {

--- a/diagnostics-app/src/app/dashboard/dashboard.module.ts
+++ b/diagnostics-app/src/app/dashboard/dashboard.module.ts
@@ -1,0 +1,20 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/**
+ * @fileoverview DashboardModule defines module for the dashboard feature.
+ * Imported by app.module.ts
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DashboardComponent } from './dashboard/dashboard.component';
+
+@NgModule({
+  declarations: [
+    DashboardComponent
+  ],
+  imports: [CommonModule],
+})
+export class DashboardModule {}

--- a/diagnostics-app/src/app/dashboard/dashboard/dashboard.component.css
+++ b/diagnostics-app/src/app/dashboard/dashboard/dashboard.component.css
@@ -1,0 +1,5 @@
+/*
+ * Copyright 2021 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */

--- a/diagnostics-app/src/app/dashboard/dashboard/dashboard.component.html
+++ b/diagnostics-app/src/app/dashboard/dashboard/dashboard.component.html
@@ -1,0 +1,7 @@
+<!--
+ Copyright 2021 The Chromium Authors. All rights reserved.
+ Use of this source code is governed by a BSD-style license that can be
+ found in the LICENSE file.
+-->
+
+<h1>Dashboard</h1>

--- a/diagnostics-app/src/app/dashboard/dashboard/dashboard.component.spec.ts
+++ b/diagnostics-app/src/app/dashboard/dashboard/dashboard.component.spec.ts
@@ -1,0 +1,33 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/**
+ * @fileoverview Defines tests for dashboard.component.ts
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DashboardComponent } from './dashboard.component';
+
+describe('DashboardComponent', () => {
+  let component: DashboardComponent;
+  let fixture: ComponentFixture<DashboardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DashboardComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DashboardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/diagnostics-app/src/app/dashboard/dashboard/dashboard.component.ts
+++ b/diagnostics-app/src/app/dashboard/dashboard/dashboard.component.ts
@@ -1,0 +1,22 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/**
+ * @fileoverview Defines the Dashboard Component.
+ * This is the root layout component which holds the dashboard.
+ * Imported by dashboard.module.ts
+ */
+
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-dashboard',
+  templateUrl: './dashboard.component.html',
+  styleUrls: ['./dashboard.component.css'],
+})
+export class DashboardComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/diagnostics-app/src/app/layout/content-layout/content-layout.component.html
+++ b/diagnostics-app/src/app/layout/content-layout/content-layout.component.html
@@ -18,6 +18,8 @@
   </mat-sidenav>
   <mat-sidenav-content>
     <app-header (toggleDrawer)="drawer.toggle()"></app-header>
-    <div class="app-content-container"></div>
+    <div class="app-content-container">
+      <router-outlet></router-outlet>
+    </div>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/diagnostics-app/src/app/layout/content-layout/content-layout.component.it.spec.ts
+++ b/diagnostics-app/src/app/layout/content-layout/content-layout.component.it.spec.ts
@@ -7,14 +7,14 @@
  */
 
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MatSidenav } from '@angular/material/sidenav';
+import { By } from '@angular/platform-browser';
 
 import { SharedModule } from 'src/app/shared/shared.module';
 
-import { ContentLayoutComponent } from './content-layout.component';
 import { HeaderComponent } from '../header/header.component';
+import { ContentLayoutComponent } from './content-layout.component';
 
 describe('integration: component ContentLayout', () => {
   let component: ContentLayoutComponent;

--- a/diagnostics-app/src/app/layout/side-nav/side-nav-item/side-nav-item.component.css
+++ b/diagnostics-app/src/app/layout/side-nav/side-nav-item/side-nav-item.component.css
@@ -10,8 +10,20 @@
 
 .mat-list-item h3 {
   font-size: 18px;
+  transition: all 0.2s ease-in-out;
 }
 
 .mat-list-item .mat-icon {
   color: var(--app-sidenav-icon-color);
+}
+
+.nav-item-active .mat-icon {
+  color: var(--app-sidenav-item-active-icon-color);
+  transition: all 0.2s ease-in-out;
+}
+
+.nav-item-active h3 {
+  color: var(--app-sidenav-item-active-color);
+  font-weight: 500;
+  transition: all 0.2s ease-in-out;
 }

--- a/diagnostics-app/src/app/layout/side-nav/side-nav-item/side-nav-item.component.html
+++ b/diagnostics-app/src/app/layout/side-nav/side-nav-item/side-nav-item.component.html
@@ -4,7 +4,13 @@
  found in the LICENSE file.
 -->
 
-<a mat-list-item class="app-side-nav-item" [routerLink]="link">
+<a
+  mat-list-item
+  class="app-side-nav-item"
+  [routerLink]="link"
+  [routerLinkActive]="'nav-item-active'"
+  [routerLinkActiveOptions]="{ exact: true }"
+>
   <mat-icon mat-list-icon>{{ icon }}</mat-icon>
   <h3 matLine>{{ name }}</h3>
 </a>

--- a/diagnostics-app/src/app/layout/side-nav/side-nav.data.ts
+++ b/diagnostics-app/src/app/layout/side-nav/side-nav.data.ts
@@ -21,5 +21,5 @@ export interface NavigationList {
 
 export const DASHBOARD_NAV_DATA: NavigationList = {
   hasHeader: false,
-  items: [{ icon: 'home', link: '/', name: 'Dashboard' }],
+  items: [{ icon: 'laptop_chromebook', link: '/dashboard', name: 'Dashboard' }],
 };

--- a/diagnostics-app/src/app/shared/material.module.ts
+++ b/diagnostics-app/src/app/shared/material.module.ts
@@ -9,13 +9,12 @@
  */
 
 import { NgModule } from '@angular/core';
-
-import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
-import { MatSidenavModule } from '@angular/material/sidenav';
-import { MatListModule } from '@angular/material/list';
 import { MatDividerModule } from '@angular/material/divider';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatToolbarModule } from '@angular/material/toolbar';
 
 @NgModule({
   imports: [

--- a/diagnostics-app/src/styles/theme.css
+++ b/diagnostics-app/src/styles/theme.css
@@ -5,10 +5,12 @@
  */
 
 .light {
+  --color-black: #000;
   --color-dark-grey: #1c1c1c;
   --color-light-grey: #2c2c2c;
   --color-lighter-grey: #d3d3d3;
   --color-white: #fff;
+  --color-blue: #4c8bf5;
 
   --app-background: var(--color-white);
 
@@ -19,6 +21,9 @@
   --app-sidenav-background: var(--color-white);
   --app-sidenav-color: var(--color-dark-grey);
   --app-sidenav-border-right-color: var(--color-lighter-grey);
+  --app-sidenav-icon-color: var(--color-darker-white);
+  --app-sidenav-item-active-icon-color: var(--color-blue);
+  --app-sidenav-item-active-color: var(--color-black);
 
   --app-content-background: var(--color-white);
   --app-content-color: var(--color-dark-grey);
@@ -27,13 +32,13 @@
 .dark {
   --color-white: #fff;
   --color-black: #000;
-
   --color-dark: #121212;
   --color-dark-grey: #1c1c1c;
   --color-light-grey: #292929;
   --color-lighter-grey: #cbcaca;
   --color-darker-white: #989898;
   --color-dark-white: #e3e3e3;
+  --color-blue: #4c8bf5;
 
   --app-header-background: var(--color-light-grey);
   --app-header-border-bottom-color: var(--color-dark-grey);
@@ -43,6 +48,8 @@
   --app-sidenav-color: var(--color-dark-white);
   --app-sidenav-subheader-color: var(--color-lighter-grey);
   --app-sidenav-icon-color: var(--color-darker-white);
+  --app-sidenav-item-active-icon-color: var(--color-blue);
+  --app-sidenav-item-active-color: var(--color-white);
 
   --app-content-background: var(--color-dark);
   --app-content-color: var(--color-white);


### PR DESCRIPTION
This pull request adds a dashboard route and component to the app. Since, now there are routes to work with: The sidenav accomodates for these changes by highlighting the current active route, i.e. `/dashboard`

**Screenshots**

![image](https://user-images.githubusercontent.com/28949397/126192336-714c181c-ff9c-41af-b173-c10c39c22091.png)

![image](https://user-images.githubusercontent.com/28949397/126192380-00e3d3ff-79f0-4c4f-b611-b21569740a41.png)
