### PR TITLE
[github] Run Angular CI when PWA is updated

### DIFF
--- a/.github/workflows/angular.test.yml
+++ b/.github/workflows/angular.test.yml
@@ -2,8 +2,12 @@ name: Angular Test CI
 on:
   push:
     branches: [ main ]
+    paths:
+      - "diagnostics-app/**"
   pull_request:
     branches: [ main ]
+    paths:
+      - "diagnostics-app/**"
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR modifies the Angular GH Action so that it only runs when `diagnostics-app` is modified in a pull request.