### PR TITLE
[ext] Add Telemetry service classes

### DIFF
--- a/diagnostics-extension/src/__tests__/telemetry.service.spec.ts
+++ b/diagnostics-extension/src/__tests__/telemetry.service.spec.ts
@@ -1,0 +1,93 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/**
+ * @fileoverview Unit tests for telemetry.service
+ */
+
+import {
+  TelemetryService,
+  TelemetryServiceProvider,
+} from '../telemetry.service';
+import * as fakeData from '../fake_telemetry.data';
+import { DpslTypes } from '../dpsl.types';
+
+describe('should return instance of FakeTelemetryService', () => {
+  const telemetryService: TelemetryService =
+    TelemetryServiceProvider.getTelemetryService();
+
+  test('should create telemetryService', () => {
+    expect(telemetryService).toBeTruthy();
+  });
+
+  test('should return same instance of telemetryService', () => {
+    const dupTelemetryService: TelemetryService =
+      TelemetryServiceProvider.getTelemetryService();
+    expect(dupTelemetryService).toStrictEqual(telemetryService);
+  });
+
+  const testCases: {
+    name: string;
+    methodUnderTest: () => Promise<DpslTypes>;
+    expectedResult: DpslTypes;
+  }[] = [
+    {
+      name: `backlight`,
+      methodUnderTest: telemetryService.getBacklightInfo,
+      expectedResult: fakeData.backlightInfo(),
+    },
+    {
+      name: `battery`,
+      methodUnderTest: telemetryService.getBatteryInfo,
+      expectedResult: fakeData.batteryInfo(),
+    },
+    {
+      name: `bluetooth`,
+      methodUnderTest: telemetryService.getBluetoothInfo,
+      expectedResult: fakeData.bluetoothInfo(),
+    },
+    {
+      name: `vpd`,
+      methodUnderTest: telemetryService.getCachedVpdInfo,
+      expectedResult: fakeData.vpdInfo(),
+    },
+    {
+      name: `cpu`,
+      methodUnderTest: telemetryService.getCpuInfo,
+      expectedResult: fakeData.cpuInfo(),
+    },
+    {
+      name: `fan`,
+      methodUnderTest: telemetryService.getFanInfo,
+      expectedResult: fakeData.fanInfo(),
+    },
+    {
+      name: `memory`,
+      methodUnderTest: telemetryService.getMemoryInfo,
+      expectedResult: fakeData.memoryInfo(),
+    },
+    {
+      name: `block device`,
+      methodUnderTest: telemetryService.getNonRemovableBlockDevicesInfo,
+      expectedResult: fakeData.blockDeviceInfo(),
+    },
+    {
+      name: `stateful partition`,
+      methodUnderTest: telemetryService.getStatefulPartitionInfo,
+      expectedResult: fakeData.statefulPartitionInfo(),
+    },
+    {
+      name: `timezone`,
+      methodUnderTest: telemetryService.getTimezoneInfo,
+      expectedResult: fakeData.timezoneInfo(),
+    },
+  ];
+
+  testCases.forEach((testCase) => {
+    test(`should fetch correct ${testCase.name} info`, async () => {
+      const data = await testCase.methodUnderTest();
+      expect(data).toStrictEqual(testCase.expectedResult);
+    });
+  });
+});

--- a/diagnostics-extension/src/dpsl.types.ts
+++ b/diagnostics-extension/src/dpsl.types.ts
@@ -236,3 +236,15 @@ export interface DiskReadRoutineParams {
   lengthSeconds: number;
   fileSizeMB: number;
 }
+
+export type DpslTypes =
+  | BacklightInfo
+  | BatteryInfo
+  | BluetoothInfo
+  | VpdInfo
+  | CpuInfo
+  | FanInfo
+  | MemoryInfo
+  | BlockDeviceInfo
+  | StatefulPartitionInfo
+  | TimezoneInfo;

--- a/diagnostics-extension/src/fake_telemetry.data.ts
+++ b/diagnostics-extension/src/fake_telemetry.data.ts
@@ -1,0 +1,133 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/**
+ * @fileoverview Functions to generate fake telemetry data.
+ */
+
+import {
+  BacklightInfo,
+  BatteryInfo,
+  BlockDeviceInfo,
+  BluetoothInfo,
+  CpuInfo,
+  FanInfo,
+  MemoryInfo,
+  StatefulPartitionInfo,
+  TimezoneInfo,
+  VpdInfo,
+} from './dpsl.types';
+
+export const backlightInfo = (): BacklightInfo => [
+  {
+    brightness: 76,
+    maxBrightness: 100,
+    path: 'unknown',
+  },
+];
+
+export const bluetoothInfo = (): BluetoothInfo => [
+  {
+    address: '94:DB:56:E6:AA:78',
+    name: 'Headphone',
+    numConnectedDevices: 1,
+    powered: true,
+  },
+];
+
+export const vpdInfo = (): VpdInfo => ({
+  skuNumber: 'sku',
+  serialNumber: 'serial-number',
+  modelName: 'model',
+});
+
+export const fanInfo = (): FanInfo => [
+  {
+    speedRpm: 2345,
+  },
+  {
+    speedRpm: 3245,
+  },
+  {
+    speedRpm: 1345,
+  },
+  {
+    speedRpm: 1350,
+  },
+];
+
+export const memoryInfo = (): MemoryInfo => ({
+  totalMemoryKib: 2000500,
+  freeMemoryKib: 1245500,
+  availableMemoryKib: 755000,
+  pageFaultsSinceLastBoot: BigInt(1200000034),
+});
+
+export const blockDeviceInfo = (): BlockDeviceInfo => [
+  {
+    path: 'path',
+    size: BigInt(12300000),
+    type: 'type',
+    manufacturerId: 1445,
+    name: 'name',
+    serial: '45xx-233-bvf',
+    bytesReadSinceLastBoot: BigInt(12300000),
+    bytesWrittenSinceLastBoot: BigInt(12300000),
+    readTimeSecondsSinceLastBoot: BigInt(12300000),
+    writeTimeSecondsSinceLastBoot: BigInt(12300000),
+    ioTimeSecondsSinceLastBoot: BigInt(12300000),
+    discardTimeSecondsSinceLastBoot: BigInt(12300000),
+  },
+];
+
+export const timezoneInfo = (): TimezoneInfo => ({
+  posix: 'IST-5:30',
+  region: 'India',
+});
+
+export const statefulPartitionInfo = (): StatefulPartitionInfo => ({
+  availableSpace: BigInt(1340000),
+  totalSpace: BigInt(2005000),
+});
+
+export const batteryInfo = (): BatteryInfo => ({
+  cycleCount: BigInt(75),
+  voltageNow: 14,
+  vendor: 'google',
+  serialNumber: 'test-bat-111',
+  chargeFullDesign: 100,
+  chargeFull: 98,
+  voltageMinDesign: 12,
+  modelName: 'best-model-111x',
+  chargeNow: 76,
+  currentNow: 4,
+  technology: 'plutonium',
+  status: 'good',
+  manufactureDate: '2019-07-09T16:59:39.787Z',
+  temperature: BigInt(43),
+});
+
+export const cpuInfo = (): CpuInfo => ({
+  numTotalThreads: 2000,
+  architecture: 'x64',
+  physicalCpus: [
+    {
+      modelName: 'intel i7-8850 8th gen',
+      logicalCpus: [
+        {
+          AcStates: [
+            {
+              name: 'ac1',
+              timeInStateSinceLastBootUs: 10300,
+            },
+          ],
+          IdleTimeMs: 5030,
+          ScalingCurrentFrequencyKhz: 1100,
+          ScalingMaxFrequencyKhz: 2000,
+          maxClockSpeedKhz: 3000,
+        },
+      ],
+    },
+  ],
+});

--- a/diagnostics-extension/src/telemetry.service.ts
+++ b/diagnostics-extension/src/telemetry.service.ts
@@ -1,0 +1,94 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/**
+ * @fileoverview Classes related to telemetry
+ */
+
+import {
+  BacklightInfo,
+  BatteryInfo,
+  BlockDeviceInfo,
+  BluetoothInfo,
+  CpuInfo,
+  FanInfo,
+  MemoryInfo,
+  StatefulPartitionInfo,
+  TimezoneInfo,
+  VpdInfo,
+} from './dpsl.types';
+import * as fakeData from './fake_telemetry.data';
+
+/**
+ * Abstract class reprensenting the interface of
+ * service to fetch system telemetry data
+ */
+export abstract class TelemetryService {
+  abstract getBacklightInfo(): Promise<BacklightInfo>;
+  abstract getBatteryInfo(): Promise<BatteryInfo>;
+  abstract getBluetoothInfo(): Promise<BluetoothInfo>;
+  abstract getCachedVpdInfo(): Promise<VpdInfo>;
+  abstract getCpuInfo(): Promise<CpuInfo>;
+  abstract getFanInfo(): Promise<FanInfo>;
+  abstract getMemoryInfo(): Promise<MemoryInfo>;
+  abstract getNonRemovableBlockDevicesInfo(): Promise<BlockDeviceInfo>;
+  abstract getStatefulPartitionInfo(): Promise<StatefulPartitionInfo>;
+  abstract getTimezoneInfo(): Promise<TimezoneInfo>;
+}
+
+/**
+ * Fake implementation of TelemetryService. Used in unit tests.
+ * @extends TelemetryService
+ */
+export class FakeTelemetryService extends TelemetryService {
+  async getBacklightInfo(): Promise<BacklightInfo> {
+    return fakeData.backlightInfo();
+  }
+  async getBatteryInfo(): Promise<BatteryInfo> {
+    return fakeData.batteryInfo();
+  }
+  async getBluetoothInfo(): Promise<BluetoothInfo> {
+    return fakeData.bluetoothInfo();
+  }
+  async getCachedVpdInfo(): Promise<VpdInfo> {
+    return fakeData.vpdInfo();
+  }
+  async getCpuInfo(): Promise<CpuInfo> {
+    return fakeData.cpuInfo();
+  }
+  async getFanInfo(): Promise<FanInfo> {
+    return fakeData.fanInfo();
+  }
+  async getMemoryInfo(): Promise<MemoryInfo> {
+    return fakeData.memoryInfo();
+  }
+  async getNonRemovableBlockDevicesInfo(): Promise<BlockDeviceInfo> {
+    return fakeData.blockDeviceInfo();
+  }
+  async getStatefulPartitionInfo(): Promise<StatefulPartitionInfo> {
+    return fakeData.statefulPartitionInfo();
+  }
+  async getTimezoneInfo(): Promise<TimezoneInfo> {
+    return fakeData.timezoneInfo();
+  }
+}
+
+/**
+ * Singleton provider for instance of Telemetry Service
+ * Returns a fake telemetry service implementation
+ * @extends TelemetryService
+ */
+export class TelemetryServiceProvider {
+  private static instance: TelemetryService;
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  private constructor() {}
+
+  public static getTelemetryService(): TelemetryService {
+    if (!TelemetryServiceProvider.instance) {
+      TelemetryServiceProvider.instance = new FakeTelemetryService();
+    }
+    return TelemetryServiceProvider.instance;
+  }
+}

--- a/diagnostics-extension/webpack.config.js
+++ b/diagnostics-extension/webpack.config.js
@@ -18,4 +18,7 @@ module.exports = {
     filename: "sw.js",
     path: path.resolve(__dirname, "build"),
   },
+  resolve: {
+    extensions: [".ts"],
+  },
 };


### PR DESCRIPTION
This pull request introduces:

* `TelemetryService` an abstract class which defines an interface for fetching system telemetry data.

* `FakeTelemetryService` extends this abstact class to provide methods which return fake telemetry data. It aims to provide sensible fake data until we interact with ChromeOS for real.

* `TelemetryServiceProvider` gives a static instance of TelemetryService. It currently returns a fake implementation. In future, it will return fake implementation for tests while actual implementation in production.