### PR TITLE
[ext] Add code coverage

### DIFF
--- a/.github/workflows/extension.test.yml
+++ b/.github/workflows/extension.test.yml
@@ -25,3 +25,5 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm run script:ci
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1

--- a/diagnostics-extension/package.json
+++ b/diagnostics-extension/package.json
@@ -7,7 +7,7 @@
     "build": "webpack",
     "postbuild": "cp -R public/** build",
     "lint": "eslint . --ext .ts",
-    "test": "jest --passWithNoTests",
+    "test": "jest --passWithNoTests --coverage",
     "script:ci": "sh ./scripts/ci.sh"
   },
   "keywords": [],


### PR DESCRIPTION
The coverage [report](https://codecov.io/github/MahmoudAGawad/cros-diag-app/commit/9f77d01570e6960564c9c1a823ca4a6c6deaf83c) is empty since there are no tests present. It will start to populate once we write tests in the extension.